### PR TITLE
INTERNAL: Skip image upload of "self-hosted" images

### DIFF
--- a/pydocxs3upload/mixins/image_upload.py
+++ b/pydocxs3upload/mixins/image_upload.py
@@ -7,7 +7,7 @@ from __future__ import (
 import time
 
 from ..util.image import get_image_data_and_filename
-from ..util.uri import get_uri_filename, uri_is_external
+from ..util.uri import get_uri_filename, uri_is_external, uri_is_self_hosted
 from ..image_upload import S3ImageUploader
 
 
@@ -27,26 +27,27 @@ class S3ImageUploadMixin(object):
         if self.first_pass or not image:
             return ''
 
-        filename = get_uri_filename(image.uri)
+        if not uri_is_self_hosted(image.uri, self.s3_bucket):
+            filename = get_uri_filename(image.uri)
 
-        if uri_is_external(image.uri):
-            image_data, filename = get_image_data_and_filename(
-                image.uri,
-                filename,
-            )
-        else:
-            image.stream.seek(0)
-            image_data = image.stream.read()
+            if uri_is_external(image.uri):
+                image_data, filename = get_image_data_and_filename(
+                    image.uri,
+                    filename,
+                )
+            else:
+                image.stream.seek(0)
+                image_data = image.stream.read()
 
-        if self.unique_filename:
-            # make sure that the filename is unique so that it will not rewrite
-            # existing images from s3
-            filename = "%s-%s" % (str(time.time()).replace('.', ''), filename)
+            if self.unique_filename:
+                # make sure that the filename is unique so that it will not rewrite
+                # existing images from s3
+                filename = "%s-%s" % (str(time.time()).replace('.', ''), filename)
 
-        s3_url = self.image_uploader.upload(image_data, filename)
+            s3_url = self.image_uploader.upload(image_data, filename)
 
-        # set the external uri to the amazon s3
-        image.uri = s3_url
+            # set the external uri to the amazon s3
+            image.uri = s3_url
 
         return super(S3ImageUploadMixin, self, ).get_image_tag(image,
                                                                width,

--- a/pydocxs3upload/util/uri.py
+++ b/pydocxs3upload/util/uri.py
@@ -57,3 +57,7 @@ def uri_is_internal(uri):
 
 def uri_is_external(uri):
     return not uri_is_internal(uri)
+
+def uri_is_self_hosted(uri, bucket_name=''):
+    s3_bucket_url = "https://%s.s3.amazonaws.com" % (bucket_name)
+    return uri.startswith(s3_bucket_url)


### PR DESCRIPTION
🎁 Summary
---
Adds support for specifying an S3 bucket name that is considered "internal", such that the upload to S3 step is skipped.


☎️ Related links and discussions
---
https://github.com/retailzipline/zipline-app/issues/20852


✋ Deployment Dependencies
---
- [ ] https://github.com/retailzipline/pydocx-resize-images/pull/15
- [ ] https://github.com/retailzipline/docx2html/pull/232


