### PR TITLE
INTERNAL: Skip image upload of "self-hosted" images - V2

### DIFF
--- a/pydocxs3upload/mixins/image_upload.py
+++ b/pydocxs3upload/mixins/image_upload.py
@@ -7,7 +7,7 @@ from __future__ import (
 import time
 
 from ..util.image import get_image_data_and_filename
-from ..util.uri import get_uri_filename, uri_is_external
+from ..util.uri import get_uri_filename, uri_is_external, uri_is_self_hosted
 from ..image_upload import S3ImageUploader
 
 
@@ -27,26 +27,27 @@ class S3ImageUploadMixin(object):
         if self.first_pass or not image:
             return ''
 
-        filename = get_uri_filename(image.uri)
+        if not uri_is_self_hosted(image.uri, self.s3_bucket):
+            filename = get_uri_filename(image.uri)
 
-        if uri_is_external(image.uri):
-            image_data, filename = get_image_data_and_filename(
-                image.uri,
-                filename,
-            )
-        else:
-            image.stream.seek(0)
-            image_data = image.stream.read()
+            if uri_is_external(image.uri):
+                image_data, filename = get_image_data_and_filename(
+                    image.uri,
+                    filename,
+                )
+            else:
+                image.stream.seek(0)
+                image_data = image.stream.read()
 
-        if self.unique_filename:
-            # make sure that the filename is unique so that it will not rewrite
-            # existing images from s3
-            filename = "%s-%s" % (str(time.time()).replace('.', ''), filename)
+            if self.unique_filename:
+                # make sure that the filename is unique so that it will not rewrite
+                # existing images from s3
+                filename = "%s-%s" % (str(time.time()).replace('.', ''), filename)
 
-        s3_url = self.image_uploader.upload(image_data, filename)
+            s3_url = self.image_uploader.upload(image_data, filename)
 
-        # set the external uri to the amazon s3
-        image.uri = s3_url
+            # set the external uri to the amazon s3
+            image.uri = s3_url
 
         return super(S3ImageUploadMixin, self, ).get_image_tag(image,
                                                                width,

--- a/pydocxs3upload/mixins/image_upload.py
+++ b/pydocxs3upload/mixins/image_upload.py
@@ -15,6 +15,7 @@ class S3ImageUploadMixin(object):
     def __init__(self, *args, **kwargs):
         s3_upload = kwargs.pop('s3_upload', None)
         self.unique_filename = kwargs.pop('unique_filename', True)
+        self.s3_bucket = kwargs.pop('s3_bucket', '')
 
         # we may specify a custom uploader class to be used
         uploader_cls = kwargs.pop('uploader_cls', S3ImageUploader)

--- a/pydocxs3upload/util/uri.py
+++ b/pydocxs3upload/util/uri.py
@@ -57,3 +57,8 @@ def uri_is_internal(uri):
 
 def uri_is_external(uri):
     return not uri_is_internal(uri)
+
+
+def uri_is_self_hosted(uri, bucket_name=''):
+    s3_bucket_url = "https://%s.s3.amazonaws.com" % (bucket_name)
+    return uri.startswith(s3_bucket_url)


### PR DESCRIPTION
Repeat of https://github.com/retailzipline/pydocx-s3-images/pull/3, but actually initialize the `s3_bucket` instance variable to avoid the error:
```
TypeError: __init__() got an unexpected keyword argument 's3_bucket'
```

See commit https://github.com/retailzipline/pydocx-s3-images/pull/5/commits/a69aa92c9cdcc5bb1b3f7760d542bdc9a775036b